### PR TITLE
Implement feature #7: Calculate individual expenses

### DIFF
--- a/src/main/java/itm/oss/splitter/App.java
+++ b/src/main/java/itm/oss/splitter/App.java
@@ -8,7 +8,7 @@ import java.util.Scanner;
 
 public class App {
 
-  private static final String DATA_FILE = "data/expenses.sample2.csv";
+  private static final String DATA_FILE = "data/expenses.sample.csv";
 
   private final Scanner sc = new Scanner(System.in);
   private final ExpenseStore store = new ExpenseStore();

--- a/src/main/java/itm/oss/splitter/App.java
+++ b/src/main/java/itm/oss/splitter/App.java
@@ -8,7 +8,7 @@ import java.util.Scanner;
 
 public class App {
 
-  private static final String DATA_FILE = "data/expenses.csv";
+  private static final String DATA_FILE = "data/expenses.sample2.csv";
 
   private final Scanner sc = new Scanner(System.in);
   private final ExpenseStore store = new ExpenseStore();

--- a/src/main/java/itm/oss/splitter/ExpenseStore.java
+++ b/src/main/java/itm/oss/splitter/ExpenseStore.java
@@ -1,15 +1,52 @@
 package itm.oss.splitter;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
 
 public class ExpenseStore {
 
-  public ArrayList<Expense> load(String path) throws IOException {
-    // TODO (Issue 1): parse CSV file into Expense list.
-    // Format: date,payer,amount,currency,participants,category,notes
-    // participants are semicolon-separated.
-    throw new UnsupportedOperationException("load() not implemented yet");
+    public ArrayList<Expense> load(String path) throws IOException {
+        // TODO (Issue 1): parse CSV file into Expense list.
+        // Format: date,payer,amount,currency,participants,category,notes
+        // participants are semicolon-separated.
+        String line = "";
+        ArrayList<Expense> expenses = new ArrayList<>();
+
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            while ((line = br.readLine()) != null) {
+                String date = "";
+                String payer = "";
+                BigDecimal amount = null;
+                String currency = "";
+                String category = "";
+                String notes = "";
+
+                String[] values = line.split(",");
+                if (Objects.equals(values[0].trim(), "date")){
+                    continue;
+                }
+
+                date = values[0];
+                payer = values[1];
+                amount = new BigDecimal(values[2]);
+                currency = values[3];
+                ArrayList<String> participants = new ArrayList<>(Arrays.asList(values[4].split(";")));
+                category = values[5];
+                notes = values[6];
+
+                Expense expense = new Expense(date, payer, amount, currency, participants, category, notes);
+                expenses.add(expense);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return expenses;
   }
 
   public void append(String path, Expense e) throws IOException {

--- a/src/main/java/itm/oss/splitter/ExpenseStore.java
+++ b/src/main/java/itm/oss/splitter/ExpenseStore.java
@@ -1,62 +1,89 @@
 package itm.oss.splitter;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.Scanner;
 
 public class ExpenseStore {
 
-    public ArrayList<Expense> load(String path) throws IOException {
-        // TODO (Issue 1): parse CSV file into Expense list.
-        // Format: date,payer,amount,currency,participants,category,notes
-        // participants are semicolon-separated.
-        String line = "";
-        ArrayList<Expense> expenses = new ArrayList<>();
+  public ArrayList<Expense> load(String path) throws IOException {
+    // TODO (Issue 1): parse CSV file into Expense list.
+    // Format: date,payer,amount,currency,participants,category,notes
+    // participants are semicolon-separated.
 
-        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
-            while ((line = br.readLine()) != null) {
-                String date = "";
-                String payer = "";
-                BigDecimal amount = null;
-                String currency = "";
-                String category = "";
-                String notes = "";
+    // path = "data/expenses.csv"
+    ArrayList<Expense> returnList = new ArrayList<>() ; // the list that we will return
 
-                String[] values = line.split(",");
-                if (Objects.equals(values[0].trim(), "date")){
-                    continue;
-                }
+    try (Scanner scanner = new Scanner(Paths.get(path))) {
+      if(scanner.hasNextLine()){ // because the first row of the csv file is headers, so we have to get rid of it 
+        scanner.nextLine(); // read one line and throw it (do not store it anywhere)
+      }
+      // we read the file until all lines have been read
+      int row_num = 1;
 
-                date = values[0];
-                payer = values[1];
-                amount = new BigDecimal(values[2]);
-                currency = values[3];
-                ArrayList<String> participants = new ArrayList<>(Arrays.asList(values[4].split(";")));
-                category = values[5];
-                notes = values[6];
+     
+      while (scanner.hasNextLine()) {
 
-                Expense expense = new Expense(date, payer, amount, currency, participants, category, notes);
-                expenses.add(expense);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
+        try{ // try block that handles the error in single line
+
+          // we read one line
+          String expenseString = scanner.nextLine();
+          String[] expenseArray = expenseString.split(",", -1);
+
+          // possible errors in single line :
+          // 1. a line has less or more than 7 elements. 
+          // 2. in String amount(expenseArray[2]), the String has some characters that are not either number or point(.)
+
+          if(expenseArray.length != 7){
+            throw new IllegalArgumentException("The number of argument in this line is not 7");
+          }
+
+          String date = expenseArray[0].trim();
+          String payer = expenseArray[1].trim();
+          BigDecimal amount = new BigDecimal(expenseArray[2].trim()); // if this is unable, NumberFormatException occurs
+          String currency = expenseArray[3].trim();
+
+          ArrayList<String> participants = new ArrayList<>(); // expenseArray[4]
+          String[] participantArray = expenseArray[4].split(";");
+          for(String participant : participantArray){
+            participants.add(participant.trim());
+          }
+
+          String category = expenseArray[5].trim();
+          String notes = expenseArray[6].trim();
+
+          Expense e = new Expense(date, payer, amount, currency, participants, category, notes);
+          returnList.add(e);
+
+        }catch(NumberFormatException e){
+          System.out.println("Error : Cannot change the String into BigDecimal, so skip row "+row_num);
+        }catch(IllegalArgumentException e){
+          System.out.println("Error : The given argument does not match the format, so skip row "+row_num);
+        }catch(Exception e){
+          System.out.println("Error: " + e.getMessage());
+        }finally{
+          row_num++ ;
         }
 
-        return expenses;
-  }
+      } // the end of while loop
 
-  public void append(String path, Expense e) throws IOException {
-    // TODO (Issue 2): append a row to CSV (create file with header if missing).
-    throw new UnsupportedOperationException("append() not implemented yet");
-  }
+    } catch (Exception e) {
+      System.out.println("Error: " + e.getMessage());
+    }
 
-  // Optional helper
-  Expense parseLine(String line) {
-    // split by comma (basic), then build Expense (participants split by ';')
-    throw new UnsupportedOperationException("parseLine() not implemented yet");
-  }
+    return returnList ;
+    }
+
+    public void append(String path, Expense e) throws IOException {
+        // TODO (Issue 2): append a row to CSV (create file with header if missing).
+        throw new UnsupportedOperationException("append() not implemented yet");
+    }
+
+    // Optional helper
+    Expense parseLine(String line) {
+        // split by comma (basic), then build Expense (participants split by ';')
+        throw new UnsupportedOperationException("parseLine() not implemented yet");
+    }
 }

--- a/src/main/java/itm/oss/splitter/PersonSummary.java
+++ b/src/main/java/itm/oss/splitter/PersonSummary.java
@@ -1,19 +1,46 @@
 package itm.oss.splitter;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class PersonSummary {
-  private BigDecimal paidTotal;
-  private BigDecimal owedTotal;
-  private BigDecimal net;
+    private BigDecimal paidTotal = BigDecimal.ZERO;
+    private BigDecimal owedTotal =  BigDecimal.ZERO;
+    private BigDecimal net =  BigDecimal.ZERO;
 
-  public PersonSummary(BigDecimal paidTotal, BigDecimal owedTotal, BigDecimal net) {
-    this.paidTotal = paidTotal;
-    this.owedTotal = owedTotal;
-    this.net = net;
-  }
+    public PersonSummary(BigDecimal paidTotal, BigDecimal owedTotal, BigDecimal net) {
+        this.paidTotal = paidTotal;
+        this.owedTotal = owedTotal;
+        this.net = net;
+    }
 
-  public BigDecimal getPaidTotal() { return paidTotal; }
-  public BigDecimal getOwedTotal() { return owedTotal; }
-  public BigDecimal getNet() { return net; }
+    public BigDecimal getPaidTotal() { return paidTotal; }
+    public BigDecimal getOwedTotal() { return owedTotal; }
+    public BigDecimal getNet() { return net; }
+
+
+    public void addPaid(BigDecimal amount) {
+        if (amount != null)
+            paidTotal = paidTotal.add(amount);
+
+        /*
+        might be redundant to call recalculateNet() each time the
+        the addPaid is called, but at the moment not
+        certain if having it off would give wrong values
+
+        for future optimization, check whether this is needed or not
+         */
+        recalculateNet();
+    }
+
+    public void addOwed(BigDecimal amount) {
+        if (amount != null)
+            owedTotal = owedTotal.add(amount);
+        recalculateNet();
+    }
+
+    private void recalculateNet() {
+        net = paidTotal.subtract(owedTotal).setScale(2, RoundingMode.HALF_UP);
+    }
+
 }

--- a/src/main/java/itm/oss/splitter/Reports.java
+++ b/src/main/java/itm/oss/splitter/Reports.java
@@ -4,15 +4,34 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public class Reports {
 
-    public SimpleMap totalsByCategory(ArrayList<Expense> xs) {
-        // TODO (Issue 6): sum amounts per category
-        throw new UnsupportedOperationException("totalsByCategory() not implemented yet");
+  public SimpleMap totalsByCategory(ArrayList<Expense> xs) {
+    LinkedHashMap<String, BigDecimal> totals = new LinkedHashMap<>();
+
+    for (int i = 0; i < xs.size(); i++) {
+      Expense e = xs.get(i);
+      String category = e.getCategory();
+
+      if (category == null || category.trim().isEmpty()) {
+        category = "Uncategorized";
+      } else {
+        category = category.substring(0, 1).toUpperCase() + category.substring(1).toLowerCase();
+      }
+      
+      BigDecimal amount = e.getAmount();
+      BigDecimal current = totals.get(category);
+      totals.put(category, current == null ? amount : current.add(amount));
     }
 
+    SimpleMap out = new SimpleMap();
+    for (String category : totals.keySet())
+      out.put(category, totals.get(category));
+    return out;
+  }
 
     /**
      * Calculates a summary of payments and debts for each person involved in expenses.

--- a/src/main/java/itm/oss/splitter/Reports.java
+++ b/src/main/java/itm/oss/splitter/Reports.java
@@ -1,16 +1,78 @@
 package itm.oss.splitter;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class Reports {
 
-  public SimpleMap totalsByCategory(ArrayList<Expense> xs) {
-    // TODO (Issue 6): sum amounts per category
-    throw new UnsupportedOperationException("totalsByCategory() not implemented yet");
-  }
+    public SimpleMap totalsByCategory(ArrayList<Expense> xs) {
+        // TODO (Issue 6): sum amounts per category
+        throw new UnsupportedOperationException("totalsByCategory() not implemented yet");
+    }
 
-  public SimplePersonSummaryMap perPerson(ArrayList<Expense> xs) {
-    // TODO (Issue 7): compute paidTotal, owedTotal, net per person
-    throw new UnsupportedOperationException("perPerson() not implemented yet");
-  }
+
+    /**
+     * Calculates a summary of payments and debts for each person involved in expenses.
+     * The algorithm:
+     * 1. For each expense, divides the amount equally among participants
+     * 2. Handles rounding issues by distributing any remainder cents to participants in alphabetical order
+     * 3. Tracks who paid what and who owes what in a SimplePersonSummaryMap
+     * 4. For each participant: records amount paid, amount owed, and calculates net balance
+     *
+     */
+    public SimplePersonSummaryMap perPerson(ArrayList<Expense> expenses) {
+        SimplePersonSummaryMap map = new SimplePersonSummaryMap();
+
+
+        for (Expense expense : expenses) {
+            List<String> participants = expense.getParticipants();
+            int count = participants.size();
+            if (count == 0) continue;
+
+            BigDecimal amount = expense.getAmount();
+
+            // Credit to Kasper (gitHub: kasperB2004) for fixing the unfair division problem
+            BigDecimal baseShare = amount.divide(new BigDecimal(count), 10, RoundingMode.DOWN);
+            BigDecimal totalBase = baseShare.multiply(new BigDecimal(count));
+            BigDecimal remainder = amount.subtract(totalBase);
+
+            List<String> sortedParticipants = new ArrayList<>(participants);
+            Collections.sort(sortedParticipants);
+
+            for (int i = 0; i < sortedParticipants.size(); i++) {
+                String name = sortedParticipants.get(i);
+
+                if (map.get(name) == null) {
+                    map.put(name, new PersonSummary(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO));
+                }
+                PersonSummary personSummary = map.get(name);
+
+                if (name.equals(expense.getPayer())) {
+                    personSummary.addPaid(amount);
+                }
+
+                // credit to Kasper (gitHub: kasperB2004) for helping to fix the cent rounding problem
+                BigDecimal owed = baseShare;
+                if (i < remainder.multiply(new BigDecimal("100")).intValue()) {
+                    owed = owed.add(new BigDecimal("0.01"));
+                }
+
+                personSummary.addOwed(owed);
+            }
+        }
+
+        // calls PersonSummary addOwed, which calls recalculateNet
+        // Recalculation of net is done so that no stale numbers get left uncalculated
+        for (String name : map.keys()) {
+            PersonSummary personSummary = map.get(name);
+            personSummary.addOwed(BigDecimal.ZERO);
+        }
+
+
+        return map;
+    }
+
 }

--- a/src/test/java/itm/oss/splitter/ReportsTest.java
+++ b/src/test/java/itm/oss/splitter/ReportsTest.java
@@ -121,7 +121,7 @@ public class ReportsTest {
             assertMoney("3.33",  m.get("Alice").getOwedTotal(), "Alice owes");
             assertMoney("3.33",  m.get("Bob").getOwedTotal(),   "Bob owes");
             assertMoney("3.33",  m.get("Cara").getOwedTotal(),  "Cara owes");
-            // If later a function for descributing remainder cents, the assertions will have to be updated.
+            // If later a function for distributing remainder cents, the assertions will have to be updated.
         }
 
         @Test

--- a/src/test/java/itm/oss/splitter/ReportsTest.java
+++ b/src/test/java/itm/oss/splitter/ReportsTest.java
@@ -1,0 +1,114 @@
+package itm.oss.splitter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ReportsTest {
+
+// simple csv file test
+
+
+// complex csv file test
+
+
+    // Issue 1 integration testing
+    @Test
+    void perPerson_usesCsvLoadedByExpenseStore() throws IOException, URISyntaxException {
+
+        // Load the CSV from test/resources (classpath)
+        var resourceUrl = getClass().getClassLoader().getResource("Expenses_Simple.csv");
+        assertNotNull(resourceUrl, "Resource Expenses_Simple.csv not found on classpath");
+
+        Path path = Path.of(resourceUrl.toURI());
+
+        ExpenseStore store = new ExpenseStore();
+        ArrayList<Expense> xs = store.load(path.toString());
+
+        // sanity check
+        assertFalse(xs.isEmpty(), "Expenses_Simple.csv should not be empty");
+
+        Reports reports = new Reports();
+        SimplePersonSummaryMap map = reports.perPerson(xs);
+
+        // Sanity on loader
+        assertEquals(3, xs.size(), "Should load three expense rows (header skipped)");
+        assertEquals("Alice", xs.get(0).getPayer(), "the payer should be alice");
+        assertEquals(new BigDecimal("60.00"), xs.get(0).getAmount(), "the amount should be 60");
+        assertEquals(3, xs.get(0).getParticipants().size(), "There should be three participants");
+    }
+
+// Unit testing
+
+        private static final RoundingMode RM = RoundingMode.HALF_UP;
+
+        private static void assertMoney(String expected, BigDecimal actual, String msg) {
+            assertEquals(new BigDecimal(expected).setScale(2, RM),
+                        actual.setScale(2, RM),
+                        msg);
+        }
+
+        // Helper from Expense
+    private static Expense exp(String payer, String amount, 
+                            List<String> participants, String category) {
+        return new Expense(
+            "2025-01-01",
+            payer,
+            new BigDecimal(amount),
+            "USD",
+            new ArrayList<>(participants),
+            category,
+            ""
+        );
+    }
+
+        @Test
+        @DisplayName("Rounding: 10.00 split by 3 uses HALF_UP in code")
+        void perPerson_roundingTenByThree() {
+            Reports reports = new Reports();
+            ArrayList<Expense> xs = new ArrayList<>();
+
+            xs.add(exp("Alice", "10.00", List.of("Alice", "Bob", "Cara"), "snacks"));
+
+            SimplePersonSummaryMap m = reports.perPerson(xs);
+            assertMoney("10.00", m.get("Alice").getPaidTotal(), "payer paid");
+            assertMoney("3.33",  m.get("Alice").getOwedTotal(), "Alice owes");
+            assertMoney("3.33",  m.get("Bob").getOwedTotal(),   "Bob owes");
+            assertMoney("3.33",  m.get("Cara").getOwedTotal(),  "Cara owes");
+            // If later a function for descributing remainder cents, the assertions will have to be updated.
+        }
+
+        @Test
+        @DisplayName("Expense with zero participants is ignored")
+        void perPerson_ignoresZeroParticipants() {
+            Reports reports = new Reports();
+            ArrayList<Expense> xs = new ArrayList<>();
+
+            xs.add(exp("Alice", "100.00", List.of(), "misc"));
+
+            SimplePersonSummaryMap m = reports.perPerson(xs);
+            assertEquals(0, m.keys().length, "No entries should be created");
+        }
+
+        @Test
+        @DisplayName("Zero-amount expense has no effect")
+        void perPerson_zeroAmount() {
+            Reports reports = new Reports();
+            ArrayList<Expense> xs = new ArrayList<>();
+
+            xs.add(exp("Alice", "0.00", List.of("Alice","Bob"), "snacks"));
+
+            SimplePersonSummaryMap m = reports.perPerson(xs);
+            assertMoney("0.00", m.get("Alice").getPaidTotal(), "Alice paid");
+            assertMoney("0.00", m.get("Bob").getOwedTotal(), "Bob owes");
+        }
+}

--- a/src/test/java/itm/oss/splitter/ReportsTest.java
+++ b/src/test/java/itm/oss/splitter/ReportsTest.java
@@ -10,11 +10,19 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ReportsTest {
+    private Reports reports;
+
+    @BeforeEach
+    void setUp() {
+        reports = new Reports();
+    }
     // Issue 1 integration testing
     @Test
     @DisplayName("Per-person summary loads correctly from sample CSV")
@@ -162,4 +170,108 @@ public class ReportsTest {
             assertMoney("100.00", m.get("Alice").getOwedTotal(), "Alice owed total");
             assertMoney("0.00", m.get("Alice").getNet(), "Paying yourself shouldn't create debt");
         }
+
+    // Tests for the Reports.totalsByCategory method
+
+    /**
+     * Tests totals by category with normal inputs, including 'Uncategorized' category handling.
+     */
+    @Test
+    @DisplayName("should calculate totals correctly for multiple categories")
+    void totalsByCategory_HappyPath() {
+        ArrayList<String> participants = new ArrayList<>(Arrays.asList("Alice", "Bob"));
+        ArrayList<Expense> expenses = new ArrayList<>();
+        expenses.add(new Expense("2024-01-01", "Alice", new BigDecimal("10.00"), "USD", participants, "Food", "Lunch"));
+        expenses.add(new Expense("2024-01-02", "Bob", new BigDecimal("20.00"), "USD", participants, "Travel", "Taxi"));
+        expenses.add(new Expense("2024-01-03", "Alice", new BigDecimal("5.50"), "USD", participants, "Food", "Snacks"));
+        expenses.add(new Expense("2024-01-04", "Cara", new BigDecimal("7.25"), "USD", participants, null, "Misc"));
+
+        SimpleMap totals = reports.totalsByCategory(expenses);
+
+        assertArrayEquals(new String[]{"Food", "Travel", "Uncategorized"}, totals.keys());
+        assertEquals(new BigDecimal("15.50"), totals.get("Food"));
+        assertEquals(new BigDecimal("20.00"), totals.get("Travel"));
+        assertEquals(new BigDecimal("7.25"), totals.get("Uncategorized"));
+    }
+
+    /**
+     * Tests behavior when the expense list is empty.
+     */
+    @Test
+    @DisplayName("should return an empty map for an empty input list")
+    void totalsByCategory_WhenInputIsEmpty() {
+        ArrayList<Expense> emptyExpenses = new ArrayList<>();
+        SimpleMap totals = reports.totalsByCategory(emptyExpenses);
+        assertEquals(0, totals.keys().length);
+    }
+
+    /**
+     * Tests correct handling when all expenses belong to a single category.
+     */
+    @Test
+    @DisplayName("should calculate total correctly when all expenses are in one category")
+    void totalsByCategory_WhenAllInOneCategory() {
+        ArrayList<String> participants = new ArrayList<>(Arrays.asList("Alice", "Bob"));
+        ArrayList<Expense> expenses = new ArrayList<>();
+        expenses.add(new Expense("2024-01-01", "Alice", new BigDecimal("10"), "USD", participants, "Entertainment", "Movie"));
+        expenses.add(new Expense("2024-01-02", "Bob", new BigDecimal("30"), "USD", participants, "Entertainment", "Concert"));
+
+        SimpleMap totals = reports.totalsByCategory(expenses);
+
+        assertEquals(1, totals.keys().length);
+        assertEquals(new BigDecimal("40"), totals.get("Entertainment"));
+    }
+
+    /**
+     * Tests handling of zero and negative amounts (refunds).
+     */
+    @Test
+    @DisplayName("should handle zero and negative amounts correctly")
+    void totalsByCategory_WithZeroAndNegativeAmounts() {
+        ArrayList<String> participants = new ArrayList<>(Arrays.asList("Alice"));
+        ArrayList<Expense> expenses = new ArrayList<>();
+        expenses.add(new Expense("2024-01-01", "Alice", new BigDecimal("50.00"), "USD", participants, "Shopping", "Jacket"));
+        expenses.add(new Expense("2024-01-02", "Alice", new BigDecimal("-10.00"), "USD", participants, "Shopping", "Jacket Refund"));
+        expenses.add(new Expense("2024-01-03", "Alice", new BigDecimal("0.00"), "USD", participants, "Shopping", "Freebie"));
+
+        SimpleMap totals = reports.totalsByCategory(expenses);
+
+        assertEquals(new BigDecimal("40.00"), totals.get("Shopping"));
+    }
+
+    /**
+     * Tests if categories with different capitalization (e.g., "Food" and "food")
+     * are treated as the same category.
+     */
+    @Test
+    @DisplayName("should treat different case categories as same category")
+    void totalsByCategory_WhenCategoriesHaveDifferentCase() {
+        ArrayList<String> participants = new ArrayList<>(Arrays.asList("Alice"));
+        ArrayList<Expense> expenses = new ArrayList<>();
+        expenses.add(new Expense("2024-01-01", "Alice", new BigDecimal("10"), "USD", participants, "Food", ""));
+        expenses.add(new Expense("2024-01-02", "Alice", new BigDecimal("20"), "USD", participants, "fOoD", ""));
+        SimpleMap totals = reports.totalsByCategory(expenses);
+
+        assertEquals(new BigDecimal("30"), totals.get("Food"), "Total for 'Food' should be 30.");
+        assertEquals(1, totals.keys().length);
+    }
+
+    /**
+     * Tests if 'null' categories and empty string "" categories and "Uncategorized"
+     * are correctly grouped together into a single "Uncategorized" category.
+     */
+    @Test
+    @DisplayName("should treat 'null' and 'Uncategorized' and 'empty string categories' as same category 'Uncategorized'")
+    void totalsByCategory_WithNullAndEmptyStringCategories() {
+        ArrayList<String> participants = new ArrayList<>(Arrays.asList("Alice"));
+        ArrayList<Expense> expenses = new ArrayList<>();
+        expenses.add(new Expense("2024-01-01", "Alice", new BigDecimal("100"), "USD", participants, null, "Null category"));
+        expenses.add(new Expense("2024-01-02", "Alice", new BigDecimal("50"), "USD", participants, "Uncategorized", "Uncategorized category"));
+        expenses.add(new Expense("2024-01-03", "Alice", new BigDecimal("20"), "USD", participants, "", "Empty string category"));
+
+        SimpleMap totals = reports.totalsByCategory(expenses);
+        assertEquals(1, totals.keys().length, "There should be only one category for null, 'Uncategorized' and empty string.");
+        assertEquals(new BigDecimal("170"), totals.get("Uncategorized"), "Total for 'Uncategorized' should be 170.");
+        assertEquals(1, totals.keys().length);
+    }
 }


### PR DESCRIPTION
This is a pull request with a contribution that fixes issue 7 and tests for it as well.

This PR solves https://github.com/ST-ITM-2025-2/expense-splitter/issues/7

Implemented the CSV file writing logic in the ExpenseStore append method.
Implemented the expenseToCSV method to convert an Expense object into a CSV string.
Added the ReportTest file
How to test: Run the program -> input 6 and enter -> the amount will now be divided between the participants

happy_path:
Correctly dividing the amount with the participants

edge_case:
empty participant list
empty expense amount
Closes https://github.com/ST-ITM-2025-2/expense-splitter/issues/7